### PR TITLE
Modify email confirmation link

### DIFF
--- a/app/Listeners/SendNewUserEmail.php
+++ b/app/Listeners/SendNewUserEmail.php
@@ -28,6 +28,8 @@ class SendNewUserEmail
     public function handle(NewUser $event)
     {
         //send email to user
-        $event->user->notify(new NewUserNotification($event->user));
+        $front_end_base = \config('app.fronend_url');
+        $confirmation_link = $front_end_base.'/auth?token='.$event->user->remember_token;
+        $event->user->notify(new NewUserNotification($event->user, $confirmation_link));
     }
 }

--- a/app/Listeners/SendNewUserEmail.php
+++ b/app/Listeners/SendNewUserEmail.php
@@ -29,7 +29,12 @@ class SendNewUserEmail
     {
         //send email to user
         $front_end_base = \config('app.fronend_url');
-        $confirmation_link = $front_end_base.'/auth?token='.$event->user->remember_token;
+        if($front_end_base) {
+            $confirmation_link = $front_end_base.'/auth?token='.$event->user->remember_token;
+        }else {
+            $confirmation_link = route('email.verify', ['token' => $event->user->remember_token]);
+        }
+        
         $event->user->notify(new NewUserNotification($event->user, $confirmation_link));
     }
 }

--- a/app/Notifications/NewUserNotification.php
+++ b/app/Notifications/NewUserNotification.php
@@ -11,16 +11,19 @@ use Illuminate\Notifications\Notification;
 class NewUserNotification extends Notification
 {
     use Queueable;
+
     protected $user;
+    protected $full_path;
 
     /**
      * Create a new notification instance.
      *
      * @return void
      */
-    public function __construct(User $user)
+    public function __construct(User $user, $full_path)
     {
         $this->user = $user;
+        $this->full_path = $full_path;
     }
 
     /**
@@ -46,7 +49,7 @@ class NewUserNotification extends Notification
                     ->line('Hello '.$this->user->name)
                     ->line('Thank you for registering on our platform')
                     ->line('Please verify your email')
-                    ->action('Verify Email', url(route('email.verify', ['token' => $this->user->remember_token])))
+                    ->action('Verify Email', $this->full_path)
                     ->line('Thank you for using our application!');
     }
 


### PR DESCRIPTION
The email confirmation link is sent to verify the users email address. This fixes allows for the frontend base url to be used to construct the link if present